### PR TITLE
Bump dependency Versions to Support Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     "landing-page"
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-json": "*",
-    "illuminate/support": "~5"
+    "illuminate/support": "^5.0|^6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0",
+    "phpunit/phpunit": "^8.0",
     "mockery/mockery": "^1.1",
-    "orchestra/testbench": "~3.0",
+    "orchestra/testbench": "^3.8|^4.0",
     "sempro/phpunit-pretty-print": "^1.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "landing-page"
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^7.2",
     "ext-json": "*",
     "illuminate/support": "^5.0|^6.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "landing-page"
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.1",
     "ext-json": "*",
     "illuminate/support": "^5.0|^6.0"
   },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->resetTestingStage();
 

--- a/tests/Unit/SubscribeTest.php
+++ b/tests/Unit/SubscribeTest.php
@@ -14,7 +14,7 @@ class SubscribeTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -26,7 +26,7 @@ class SubscribeTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Unit/SubscriberTest.php
+++ b/tests/Unit/SubscriberTest.php
@@ -22,7 +22,7 @@ class SubscriberTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
## Summary of Changes
* Change Versions of dependencies to Support Laravel 6.
* Modified Tests to Properly implement new PHP typed returns like:
```php
protected function setUp() {}
```
to
```php
protected function setUp():void {}
```
## Test Instructions
Install on a Laravel 5 project and then on a Laravel 6 Project

## Expected Outcome
Should install on both a Laravel 5 Project and a Laravel 6 Project