### PR TITLE
Declare support for PHP 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "landing-page"
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },


### PR DESCRIPTION
I've checked the code against the [PHP Compatibility Coding Standard for PHP CodeSniffer](https://github.com/PHPCompatibility/PHPCompatibility) using the following command:

```phpcs -p . --standard=PHPCompatibility --runtime-set testVersion 8.0```

All looks good, and functions fine.